### PR TITLE
bug: Specify the folder of test cases #64

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -33,4 +33,4 @@ jobs:
           COMMIT_TOKEN: ${{ secrets.COMMIT_TOKEN }}
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
         run: |
-          pytest
+          pytest tests/

--- a/src/test.py
+++ b/src/test.py
@@ -8,7 +8,7 @@ from config import TMP_DIR
 
 def run_test():
     try:
-        run_command("pytest", TMP_DIR)
+        run_command("pytest tests/", TMP_DIR)
 
     except subprocess.CalledProcessError:
         raise Exception("test: Test fails, check the logs")

--- a/tests/test_test.py
+++ b/tests/test_test.py
@@ -10,11 +10,11 @@ def test_run_test_success():
         except Exception:
             pytest.fail("run_test() raised Exception unexpectedly!")
 
-        mock_run_command.assert_called_once_with("pytest", TMP_DIR)
+        mock_run_command.assert_called_once_with("pytest tests/", TMP_DIR)
 
 def test_run_test_failure():
-    with patch("src.test.run_command", side_effect=subprocess.CalledProcessError(1, "pytest")) as mock_run_command:
+    with patch("src.test.run_command", side_effect=subprocess.CalledProcessError(1, "pytest tests/")) as mock_run_command:
         with pytest.raises(Exception, match="test: Test fails, check the logs"):
             run_test()
 
-        mock_run_command.assert_called_once_with("pytest", TMP_DIR)
+        mock_run_command.assert_called_once_with("pytest tests/", TMP_DIR)


### PR DESCRIPTION
This specifies the folder of pytest, so that it only executes test cases under /tests